### PR TITLE
feat: file duplicate protection, tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.1.0] - 2026-04-09
+
+### Summary
+- File duplicate protection added via kernel32
+- Added tests `./src/obsidian_sync/tests`
+
+### Added
+- `ICloudStatusChecker` reads Windows file attributes via `GetFileAttributesW` (kernel32) to determine iCloud sync state
+- `ICloudSyncState` enum with states: `LOCAL`, `PINNED`, `PENDING`, `DOWNLOADING`, `CLOUD_ONLY`, `UNKNOWN`
+- iCloud status guard defers processing of files that are not yet locally available
+- If local file has changed relative to history (`L != H`), push proceeds even over a cloud-only placeholder
+- `RtlSetProcessPlaceholderCompatibilityMode(PHCM_EXPOSE_PLACEHOLDERS)` ensures placeholder attributes are not hidden by the OS
+- New config values: `user_interface: true` and `check_icloud_status: true`
+
 ## [1.0.1] - 2026-04-05
 
 ### Summary

--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,9 @@ paths:
   logs_dir: "C:\\Obsidian\\Logs"
 
 sync:
-  run_continuously: false
+  run_continuously: true
+  user_interface: true #TODO Implement UI
+  check_icloud_status: true
   poll_interval: 2
   stability_window: 3
   stabilize_wait: 8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "obsidian-sync"
-version = "1.0.1"
+version = "1.1.0"
 description = "Async three-way sync engine for Obsidian vaults between Windows and iCloud Drive"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -13,6 +13,7 @@ dependencies = [
     "colorama>=0.4.6",
     "aiofiles>=23.2.1",
     "pyyaml>=6.0",
+    "pytest>=9.0.3",
 ]
 
 [project.scripts]

--- a/src/obsidian_sync/config.py
+++ b/src/obsidian_sync/config.py
@@ -4,6 +4,9 @@ from dataclasses import dataclass, field
 
 import yaml
 
+DEFAULT_IGNORED_DIRS = {'.trash', '.fseventsd', '.spotlight-v100', '.apdisk'}
+DEFAULT_IGNORED_FILES = {'.ds_store', '.trash', 'workspace.json', 'workspace-mobile.json'}
+
 @dataclass
 class SyncConfig:
     """
@@ -16,6 +19,8 @@ class SyncConfig:
     logs_dir: str = ""
     # Sync
     run_continuously: bool = True
+    user_interface: bool = True
+    check_icloud_status: bool = True
     poll_interval: int = 2
     stability_window: int = 3
     stabilize_wait: int = 8
@@ -31,12 +36,8 @@ class SyncConfig:
     log_retention: int = 10
     # Ignore
     ignore_patterns: list[str] = field(default_factory=list)
-    ignored_dirs: set[str] = field(default_factory=lambda: {
-        '.trash', '.fseventsd', '.spotlight-v100', '.apdisk'
-    })
-    ignored_files: set[str] = field(default_factory=lambda: {
-        '.ds_store', '.trash', 'workspace.json', 'workspace-mobile.json'
-    })
+    ignored_dirs: set[str] = field(default_factory=lambda: set(DEFAULT_IGNORED_DIRS))
+    ignored_files: set[str] = field(default_factory=lambda: set(DEFAULT_IGNORED_FILES))
 
     @classmethod
     def from_yaml(cls, path: str) -> "SyncConfig":
@@ -71,6 +72,8 @@ class SyncConfig:
             history_dir=paths.get("history_dir", ""),
             logs_dir=paths.get("logs_dir", ""),
             run_continuously=sync.get("run_continuously", True),
+            user_interface=sync.get("user_interface", True),
+            check_icloud_status=sync.get("check_icloud_status", True),
             poll_interval=sync.get("poll_interval", 2),
             stability_window=sync.get("stability_window", 3),
             stabilize_wait=sync.get("stabilize_wait", 8),
@@ -84,12 +87,8 @@ class SyncConfig:
             max_display_length=logging_cfg.get("max_display_length", 50),
             log_retention=logging_cfg.get("log_retention", 10),
             ignore_patterns=ignore.get("patterns", []),
-            ignored_dirs=set(ignore.get("dirs", [
-                '.trash', '.fseventsd', '.spotlight-v100', '.apdisk'
-            ])),
-            ignored_files=set(ignore.get("files", [
-                '.ds_store', '.trash', 'workspace.json', 'workspace-mobile.json'
-            ])),
+            ignored_dirs=set(ignore.get("dirs", DEFAULT_IGNORED_DIRS)),
+            ignored_files=set(ignore.get("files", DEFAULT_IGNORED_FILES)),
         )
 
     @property
@@ -139,6 +138,12 @@ class SyncConfig:
             if '//' in p or p.startswith('/'):
                 errors.append(("suspicious_ignore_pattern", "warn", f"Suspicious ignore pattern: '{p}'"))
 
+        if self.poll_interval <= 0:
+            errors.append(("invalid_value", "critical", "poll_interval must be positive"))
+
+        if self.stability_window < 0:
+            errors.append(("invalid_value", "critical", "stability_window cannot be negative"))
+
         return errors
 
     def is_ignored(self, rel_path: str) -> bool:
@@ -150,9 +155,9 @@ class SyncConfig:
         Returns:
             bool: True if the path should be ignored, False otherwise.
         """
-        rel = rel_path.replace(os.sep, '/').lower()
+        rel = rel_path.replace('\\', '/').replace(os.sep, '/').lower()
         for pattern in self.ignore_patterns:
-            pat = pattern.replace(os.sep, '/').lower()
+            pat = pattern.replace('\\', '/').replace(os.sep, '/').lower()
             if rel == pat:
                 return True
             if fnmatch.fnmatch(rel, pat):
@@ -173,11 +178,13 @@ class SyncConfig:
         if not self.shorter_paths:
             return path
         if os.path.isabs(path):
+            matched = False
             for root in [self.local_vault, self.icloud_vault, self.history_dir]:
                 if root and (path == root or path.startswith(root + os.sep)):
                     path = os.path.relpath(path, root)
+                    matched = True
                     break
-            else:
+            if not matched:
                 return os.path.basename(path)
         if len(path) <= self.max_display_length:
             return path

--- a/src/obsidian_sync/disk_io.py
+++ b/src/obsidian_sync/disk_io.py
@@ -5,22 +5,14 @@ import ctypes
 import platform
 
 from datetime import datetime
+from ctypes import wintypes
 
 # ── Windows API ──────────────────────────────────────────────────
 MOVEFILE_REPLACE_EXISTING = 0x1
 MOVEFILE_WRITE_THROUGH = 0x8
 FILE_ATTRIBUTE_NORMAL = 0x80
 
-if platform.system() in ("Windows", "Microsoft"):
-    from ctypes import wintypes
-    kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
-    MoveFileExW = kernel32.MoveFileExW
-    MoveFileExW.argtypes = (wintypes.LPCWSTR, wintypes.LPCWSTR, wintypes.DWORD)
-    MoveFileExW.restype = wintypes.BOOL
-    SetFileAttributesW = kernel32.SetFileAttributesW
-    SetFileAttributesW.argtypes = (wintypes.LPCWSTR, wintypes.DWORD)
-    SetFileAttributesW.restype = wintypes.BOOL
-else:
+if not platform.system() in ("Windows", "Microsoft"):
     MoveFileExW = None
     SetFileAttributesW = None
 
@@ -100,6 +92,13 @@ class DiskIO:
             raise RuntimeError("Disk operations are only supported on Windows.")
         self.config = config
         self.log = logger
+        kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
+        MoveFileExW = kernel32.MoveFileExW
+        MoveFileExW.argtypes = (wintypes.LPCWSTR, wintypes.LPCWSTR, wintypes.DWORD)
+        MoveFileExW.restype = wintypes.BOOL
+        SetFileAttributesW = kernel32.SetFileAttributesW
+        SetFileAttributesW.argtypes = (wintypes.LPCWSTR, wintypes.DWORD)
+        SetFileAttributesW.restype = wintypes.BOOL
 
     def set_normal_attributes(self, path: str) -> bool:
         """
@@ -113,7 +112,7 @@ class DiskIO:
         try:
             if not os.path.exists(path):
                 return True
-            return bool(SetFileAttributesW(path, FILE_ATTRIBUTE_NORMAL))
+            return bool(self._k32.SetFileAttributesW(str(path), FILE_ATTRIBUTE_NORMAL))
         except Exception:
             return False
 
@@ -161,6 +160,9 @@ class DiskIO:
                 if attempt >= max_retries:
                     # Win32 MoveFileEx fallback
                     try:
+                        if MoveFileExW is None:
+                            self.log.error("FAILED", "MoveFileExW unavailable on this platform")
+                            raise PermissionError(f"Unable to replace {dst}")
                         ok = MoveFileExW(tmp, dst, MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)
                         if ok:
                             self.log.success("SUCCESS", f"MoveFileEx: {self.config.disp(dst)}", level="verbose")

--- a/src/obsidian_sync/duplicates.py
+++ b/src/obsidian_sync/duplicates.py
@@ -40,7 +40,8 @@ class DuplicateScanner:
             if not root_dir or not os.path.exists(root_dir):
                 continue
             for dirpath, _, filenames in os.walk(root_dir):
-                if '.trash' in dirpath.lower().split(os.sep):
+                parts = dirpath.replace('\\', '/').lower().split('/')
+                if '.trash' in parts:
                     continue
                 for f in filenames:
                     if conflict_re.search(f) or icloud_dup_re.search(f) or tmp_re.search(f):
@@ -56,7 +57,12 @@ class DuplicateScanner:
 
         self.log.warn("ACTION", "Delete them WITHOUT RECOVERY before sync? (y/N)", level="important")
         sys.stdout.flush()
-        ans = input().strip().lower()
+        try:
+            ans = input().strip().lower()
+        except KeyboardInterrupt:
+            print()
+            self.log.warn("INFO", "Interrupted, skipping duplicate cleanup.", level="important")
+            return
 
         if ans in ('y', 'yes'):
             failed_deletions = []

--- a/src/obsidian_sync/hasher.py
+++ b/src/obsidian_sync/hasher.py
@@ -36,7 +36,10 @@ class FileHasher:
             return
         try:
             with open(path, "r", encoding="utf-8") as f:
-                self.state = json.load(f)
+                data = json.load(f)
+                if not isinstance(data, dict):
+                    raise ValueError(f"State file has unexpected format: {type(data)}")
+                self.state = data
         except Exception as e:
             self.log.warn("WARNING", f"Loading state file failed: {e}", level="important")
             try:
@@ -77,7 +80,7 @@ class FileHasher:
         Returns:
             Optional[str]: The computed SHA-256 hex digest, or None if the file doesn't exist or couldn't be read after all retries.
         """
-        if not os.path.exists(path):
+        if not safe_exists(path):
             return None
         attempt = 0
         backoff = 0.05

--- a/src/obsidian_sync/icloud_status.py
+++ b/src/obsidian_sync/icloud_status.py
@@ -1,0 +1,121 @@
+import ctypes
+import platform
+from enum import Enum
+
+FILE_ATTRIBUTE_OFFLINE = 0x00001000  # "O" - only in cloud, not local
+FILE_ATTRIBUTE_PINNED = 0x00080000  # "P" - always local (pinned)
+FILE_ATTRIBUTE_UNPINNED = 0x00100000  # "U" - not pinned, can be evicted from local storage
+FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS = 0x00400000  # "R" - recall on access, needs to be downloaded before use
+FILE_ATTRIBUTE_RECALL_ON_OPEN  = 0x00040000  # FILE_ATTRIBUTE_EA - "RO" - recall on open, needs to be downloaded before opening
+FILE_ATTRIBUTE_REPARSE_POINT = 0x00000400 # "L" - placeholder (symlink), not a regular file
+
+class ICloudSyncState(Enum):
+    """
+    All possible states of iCloud file synchronization, determined by Windows file attributes
+    """
+    CLOUD_ONLY = "cloud_only"
+    PENDING = "pending"
+    DOWNLOADING = "downloading"
+    LOCAL = "local"
+    PINNED  = "pinned"
+    UNKNOWN = "unknown"
+
+    @property
+    def is_safe(self) -> bool:
+        """
+        Returns:
+            bool: True if the file is safe to read/copy (i.e., has local content available)
+        """
+        return self in (ICloudSyncState.LOCAL, ICloudSyncState.PINNED)
+
+    @property
+    def status(self) -> str:
+        """
+        Simple status for logging
+
+        Returns:
+            str: A short status string for logging purposes.
+        """
+        return {
+            ICloudSyncState.CLOUD_ONLY: "iCloud-only",
+            ICloudSyncState.DOWNLOADING: "Downloading",
+            ICloudSyncState.PENDING: "Pending",
+            ICloudSyncState.LOCAL: "Local",
+            ICloudSyncState.PINNED: "Pinned",
+            ICloudSyncState.UNKNOWN: "Unknown",
+        }.get(self, "?")
+
+
+class ICloudStatusChecker:
+    """
+    Checks iCloud sync status of files on Windows by reading file attributes, uses Windows API via ctypes
+    """
+    def __init__(self):
+        self._available = platform.system() in ("Windows", "Microsoft")
+        if self._available:
+            try:
+                self._k32 = ctypes.WinDLL('kernel32', use_last_error=True)
+                self._k32.GetFileAttributesW.argtypes = [ctypes.c_wchar_p]
+                self._k32.GetFileAttributesW.restype = ctypes.c_uint32
+                # PHCM_EXPOSE_PLACEHOLDERS
+                try:
+                    ntdll = ctypes.WinDLL('ntdll')
+                    ntdll.RtlSetProcessPlaceholderCompatibilityMode(2)
+                except Exception:
+                    pass
+            except (AttributeError, OSError):
+                self._available = False
+                self._k32 = None
+        else:
+            self._k32 = None
+
+    def detect(self, path: str) -> ICloudSyncState:
+        """
+        Checks the iCloud sync status of a file on Windows by reading its file attributes.
+
+        Args:
+            path: The absolute path to the file (iCloud vault).
+        Returns:
+            ICloudSyncState corresponding to the current status of the file.
+        """
+        if not self._available:
+            return ICloudSyncState.UNKNOWN
+
+        try:
+            attrs = self._k32.GetFileAttributesW(str(path))
+        except Exception:
+            return ICloudSyncState.UNKNOWN
+        if attrs == 0xFFFFFFFF:
+            return ICloudSyncState.UNKNOWN
+
+        is_offline = bool(attrs & FILE_ATTRIBUTE_OFFLINE)
+        is_pinned = bool(attrs & FILE_ATTRIBUTE_PINNED)
+        is_unpinned = bool(attrs & FILE_ATTRIBUTE_UNPINNED)
+        is_recall = bool(attrs & (FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS | FILE_ATTRIBUTE_RECALL_ON_OPEN))
+        is_reparse = bool(attrs & FILE_ATTRIBUTE_REPARSE_POINT)
+
+        if is_offline and is_pinned:
+            return ICloudSyncState.DOWNLOADING
+        elif is_offline and is_recall:
+            return ICloudSyncState.PENDING
+        # WARNING: no symlinks in vaults allowed, otherwise they will be detected as cloud-only and skipped
+        elif is_offline or is_recall or (is_reparse and not is_pinned):
+            return ICloudSyncState.CLOUD_ONLY
+        elif is_pinned:
+            return ICloudSyncState.PINNED
+        elif is_unpinned:
+            return ICloudSyncState.LOCAL
+        else:
+            return ICloudSyncState.LOCAL
+
+    def is_safe(self, path: str) -> bool:
+        """
+        Checks if a file is safe to read/copy (i.e., has local content available).
+
+        Args:
+            path: The absolute path to the file.
+        Returns:
+            bool: True if the file is safe to read/copy, False otherwise.
+        """
+        state = self.detect(path)
+        return state.is_safe or state == ICloudSyncState.UNKNOWN

--- a/src/obsidian_sync/logger.py
+++ b/src/obsidian_sync/logger.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from colorama import Fore, Style, init as colorama_init
 
 LEVEL_MAP = {"quiet": 0, "normal": 10, "verbose": 100, "important": 1000}
-_ANSI_RE = re.compile(r'\x1b\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]')
+ANSI_REPLACE = re.compile(r'\x1b\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]')
 
 def strip_ansi(text: str) -> str:
     """
@@ -18,7 +18,7 @@ def strip_ansi(text: str) -> str:
     Returns:
         str: The plain text string suitable for writing to standard log files.
     """
-    return _ANSI_RE.sub('', text)
+    return ANSI_REPLACE.sub('', text)
 
 def colored(text: str, color) -> str:
     """
@@ -148,7 +148,7 @@ class SyncLogger:
             self.write_to_file("ERROR", "Critical error. Stopping to prevent data loss.")
             self.flush()
             self.console_event("🔴", Fore.RED, "ERROR", "Critical error. Stopping to prevent data loss.", level="important")
-            sys.exit(1)
+            raise SystemExit(1)
 
     def success(self, msg_type: str, msg: str, level: str = "important"):
         """
@@ -242,6 +242,7 @@ class SyncLogger:
             if len(logs) <= keep:
                 return
             for old in logs[:-keep]:
-                await asyncio.to_thread(os.remove, old)
+                if old != self.log_file:
+                    await asyncio.to_thread(os.remove, old)
         except Exception as e:
             self.console_event("🔴", Fore.RED, "FAILED", f"Log Cleanup Failed: {e}", level="important")

--- a/src/obsidian_sync/sync_engine.py
+++ b/src/obsidian_sync/sync_engine.py
@@ -7,6 +7,7 @@ from colorama import Fore
 
 from .logger import colored
 from .disk_io import safe_exists, size_or_zero, safe_mtime, ensure_dir
+from .icloud_status import ICloudStatusChecker, ICloudSyncState
 
 class SyncEngine:
     """
@@ -31,6 +32,10 @@ class SyncEngine:
         self.cooldowns: dict[str, float] = {}
         self.active_tasks: set[str] = set()
         self.io_semaphore = asyncio.Semaphore(self.config.max_concurrent_io)
+        if config.check_icloud_status:
+            self.icloud_checker = ICloudStatusChecker()
+        else:
+            self.icloud_checker = None
 
     # ── Core file operations ─────────────────────────────────────
 
@@ -153,6 +158,22 @@ class SyncEngine:
         C_exists = safe_exists(icloud)
         H_exists = safe_exists(history)
 
+        # ── iCloud status guard ──
+        if cfg.check_icloud_status and self.icloud_checker and C_exists:
+            state = self.icloud_checker.detect(icloud)
+            if not state.is_safe and state != ICloudSyncState.UNKNOWN:
+                can_push = False
+                if L_exists and H_exists:
+                    L_hash = await self.hasher.get_cached_hash(local, 'L', rel_path)
+                    H_hash = await self.hasher.get_cached_hash(history, 'H', rel_path)
+                    can_push = L_hash is not None and H_hash is not None and L_hash != H_hash
+                if can_push:
+                    self.log.info("ICLOUD_WAIT", f"[{state.status}] Local changed, pushing over placeholder: {d}", level="verbose")
+                    await self.push_to_icloud(rel_path)
+                    return
+                self.log.info("ICLOUD_WAIT", f"[{state.status}] Waiting {d}", level="verbose")
+                return
+
         # ── Nothing exists anywhere ──
         if not L_exists and not C_exists:
             if H_exists:
@@ -197,7 +218,7 @@ class SyncEngine:
             if Lh is None:
                 self.log.info("SKIP", f"After stabilize local missing for {d}", level="verbose")
                 return
-            if size_or_zero(local) < cfg.tiny_threshold:
+            if size_or_zero(local) < cfg.min_seed_size(rel_path):
                 self.log.info("SKIP", f"Local too small, deferring {d}", level="verbose")
                 return
             self.log.custom([" ↑", "⚪"], [Fore.GREEN, Fore.GREEN], "PUSH", f"{colored('Pushing to iCloud', Fore.CYAN)} for {d}", rel_path, level="verbose")
@@ -286,6 +307,11 @@ class SyncEngine:
         L2 = await self.hasher.get_cached_hash(local, 'L', rel_path, force=True) if safe_exists(local) else None
         C2 = await self.hasher.get_cached_hash(icloud, 'C', rel_path, force=True) if safe_exists(icloud) else None
 
+        if L2 is not None and C2 is not None and L2 == C2:
+            await self.io.async_copy(local, history)
+            self.log.info("RESOLVED", f"Both stabilized to same content for {d}", level="verbose")
+            return
+
         if L2 is not None and L2 != L:
             self.log.warn("CONFLICT", f"{colored('Local still changing', Fore.YELLOW)}, choose local: {d}", level="important")
             await self.io.create_conflict_duplicate(icloud)
@@ -355,12 +381,13 @@ class SyncEngine:
 
         # Validate config
         errors = cfg.validate()
+        missing_dirs = [e for e in errors if e[0] == "dir_missing"]
+        if missing_dirs:
+            for path in [cfg.history_dir, cfg.logs_dir]:
+                if path:
+                    os.makedirs(path, exist_ok=True)
+
         for error, level, msg in errors:
-            if error == "dir_missing":
-                if not cfg.history_dir or not os.path.exists(cfg.history_dir):
-                    os.makedirs(cfg.history_dir, exist_ok=True)
-                if not cfg.logs_dir or not os.path.exists(cfg.logs_dir):
-                    os.makedirs(cfg.logs_dir, exist_ok=True)
             if level == "critical":
                 self.log.error("CONFIG", msg, level="important")
                 raise ValueError(f"Critical configuration error: {msg}")
@@ -400,9 +427,7 @@ class SyncEngine:
                     # One-shot mode: wait and exit
                     if not cfg.run_continuously:
                         if tasks:
-                            self.log.info("INFO",
-                                          f"One-shot: waiting for {len(tasks)} tasks...",
-                                          level="normal")
+                            self.log.info("INFO", f"One-shot: waiting for {len(tasks)} tasks...", level="normal")
                             await asyncio.gather(*tasks)
                         else:
                             self.log.info("INFO", "Nothing to sync.", level="normal")
@@ -417,11 +442,9 @@ class SyncEngine:
 
                     # Periodic state save (every 5s)
                     now_t = time.time()
-                    if self.hasher.dirty and now_t - last_save > 5:
-                        self.hasher.save_state()
-                        self.log.flush()
-                        last_save = now_t
-                    elif now_t - last_save > 5:
+                    if now_t - last_save > 5:
+                        if self.hasher.dirty:
+                            self.hasher.save_state()
                         self.log.flush()
                         last_save = now_t
 

--- a/src/obsidian_sync/tests/conftest.py
+++ b/src/obsidian_sync/tests/conftest.py
@@ -1,0 +1,141 @@
+import sys, os, types, ctypes, importlib.util
+import pytest
+import warnings
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+SOURCE_FILES_DIR = Path(__file__).parent.parent
+MODULE_FILES = {
+    "config": "config.py",
+    "logger": "logger.py",
+    "disk_io": "disk_io.py",
+    "hasher": "hasher.py",
+    "duplicates": "duplicates.py",
+    "sync_engine": "sync_engine.py",
+    "icloud_status": "icloud_status.py",
+}
+PKG = "obsidian_sync"
+
+mock_k32 = MagicMock(name="kernel32")
+mock_windll = MagicMock(name="windll")
+mock_windll.kernel32 = mock_k32
+
+_wt = types.ModuleType("ctypes.wintypes")
+_wt.LPCWSTR = ctypes.c_wchar_p
+_wt.DWORD = ctypes.c_uint32
+_wt.BOOL = ctypes.c_int
+sys.modules.setdefault("ctypes.wintypes", _wt)
+if not hasattr(ctypes, "WinDLL"):
+    ctypes.WinDLL = MagicMock(return_value=mock_k32)
+
+def _load(sub):
+    fname = MODULE_FILES.get(sub, sub + ".py")
+    path  = SOURCE_FILES_DIR / fname
+    if not path.exists():
+        stub = types.ModuleType(f"{PKG}.{sub}")
+        sys.modules[f"{PKG}.{sub}"] = stub
+        return stub
+    spec = importlib.util.spec_from_file_location(f"{PKG}.{sub}", path)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = PKG
+    sys.modules[f"{PKG}.{sub}"] = mod
+    with patch("platform.system", return_value="Windows", create=True), \
+         patch("ctypes.windll", mock_windll, create=True), \
+         patch("ctypes.WinDLL", MagicMock(return_value=mock_k32), create=True):
+        try:
+            spec.loader.exec_module(mod)
+        except Exception as e:
+            warnings.warn(f"[conftest] Failed to load '{sub}': {e}", stacklevel=2)
+            stub = types.ModuleType(f"{PKG}.{sub}")
+            stub._load_error = str(e)
+            sys.modules[f"{PKG}.{sub}"] = stub
+            return stub
+    return mod
+
+_mods = {s: _load(s) for s in ("config","logger","disk_io","hasher","duplicates","icloud_status","sync_engine")}
+
+def _get(mn, attr):
+    m = _mods.get(mn)
+    if m and hasattr(m, attr):
+        return getattr(m, attr)
+    warnings.warn(f"[conftest] '{mn}.{attr}' not found, using MagicMock", stacklevel=2)
+    return MagicMock()
+
+SyncConfig = _get("config", "SyncConfig")
+SyncLogger = _get("logger", "SyncLogger")
+strip_ansi = _get("logger", "strip_ansi")
+colored = _get("logger", "colored")
+LEVEL_MAP = _get("logger", "LEVEL_MAP")
+DiskIO = _get("disk_io", "DiskIO")
+safe_exists = _get("disk_io", "safe_exists")
+size_or_zero = _get("disk_io", "size_or_zero")
+safe_mtime = _get("disk_io", "safe_mtime")
+ensure_dir = _get("disk_io", "ensure_dir")
+FileHasher = _get("hasher", "FileHasher")
+DuplicateScanner = _get("duplicates", "DuplicateScanner")
+SyncEngine = _get("sync_engine", "SyncEngine")
+ICloudStatusChecker = _get("icloud_status","ICloudStatusChecker")
+ICloudSyncState = _get("icloud_status","ICloudSyncState")
+
+try:
+    _icm = _mods["icloud_status"]
+    FILE_ATTRIBUTE_OFFLINE = _icm.FILE_ATTRIBUTE_OFFLINE
+    FILE_ATTRIBUTE_PINNED = _icm.FILE_ATTRIBUTE_PINNED
+    FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS = _icm.FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS
+    FILE_ATTRIBUTE_REPARSE_POINT = _icm.FILE_ATTRIBUTE_REPARSE_POINT
+except AttributeError as e:
+    import warnings
+    warnings.warn(f"[conftest] icloud_status constants not found: {e}")
+    FILE_ATTRIBUTE_OFFLINE = 0x00001000
+    FILE_ATTRIBUTE_PINNED = 0x00080000
+    FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS = 0x00400000
+    FILE_ATTRIBUTE_REPARSE_POINT = 0x00000400
+
+@pytest.fixture
+def cfg(tmp_path):
+    for d in ("local", "icloud", "history", "logs"):
+        (tmp_path / d).mkdir()
+    c = SyncConfig()
+    c.local_vault = str(tmp_path / "local")
+    c.icloud_vault = str(tmp_path / "icloud")
+    c.history_dir = str(tmp_path / "history")
+    c.logs_dir = str(tmp_path / "logs")
+    c.run_continuously = False
+    c.user_interface = False
+    c.check_icloud_status = True
+    c.poll_interval = 2
+    c.stability_window = 0
+    c.stabilize_wait = 0
+    c.cooldown_seconds = 0
+    c.big_file_cooldown = 0
+    c.big_file_threshold = 100 * 1024
+    c.tiny_threshold = 8
+    c.max_concurrent_io = 50
+    c.console_level = "quiet"
+    c.check_icloud_status = False
+    c.ignore_patterns = []
+    c.ignored_dirs = set()
+    c.ignored_files = set()
+    c.shorter_paths = True
+    c.max_display_length = 60
+    c.log_retention = 5
+    c.conflict_resolution = "newer"
+    return c
+
+@pytest.fixture
+def mock_log(): return MagicMock(spec=SyncLogger)
+
+@pytest.fixture
+def mock_disk_io(): return MagicMock()
+
+@pytest.fixture
+def hasher(cfg, mock_log):
+    h = FileHasher(cfg, mock_log); h.state = {}; h.dirty = False; return h
+
+@pytest.fixture
+def eng(cfg, mock_log):
+    with patch("platform.system", return_value="Windows", create=True):
+        io = DiskIO(cfg, mock_log)
+    h = FileHasher(cfg, mock_log); h.state = {}
+    return SyncEngine(cfg, mock_log, h, io, MagicMock())

--- a/src/obsidian_sync/tests/pytest.ini
+++ b/src/obsidian_sync/tests/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+asyncio_mode = auto
+testpaths = .
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*

--- a/src/obsidian_sync/tests/test_config.py
+++ b/src/obsidian_sync/tests/test_config.py
@@ -1,0 +1,242 @@
+import os
+import pytest
+import yaml
+from unittest.mock import patch, mock_open
+from conftest import SyncConfig
+
+# ── Fixtures ──
+
+@pytest.fixture
+def valid_yaml(tmp_path):
+    local = tmp_path / "local"; local.mkdir()
+    icloud = tmp_path / "icloud"; icloud.mkdir()
+    history = tmp_path / "history"; history.mkdir()
+    logs = tmp_path / "logs"; logs.mkdir()
+    data = {
+        "paths": {
+            "local_vault": str(local),
+            "icloud_vault": str(icloud),
+            "history_dir": str(history),
+            "logs_dir": str(logs),
+        },
+        "sync": {
+            "run_continuously": True,
+            "user_interface": False,
+            "check_icloud_status": True,
+            "poll_interval": 5,
+            "stability_window": 3,
+            "check_icloud_status": True,
+        },
+        "logging": {
+            "console_level": "verbose"
+        },
+        "ignore": {
+            "patterns": ["*.tmp"],
+            "dirs": [".trash"],
+            "files": [".ds_store"]
+        },
+    }
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.dump(data))
+    return path, data, tmp_path
+
+# ── from_yaml ──
+
+class TestFromYaml:
+    def test_loads_valid_yaml(self, valid_yaml):
+        path, data, tmp = valid_yaml
+        cfg = SyncConfig.from_yaml(str(path))
+        assert cfg.poll_interval == 5
+        assert cfg.stability_window == 3
+        assert cfg.console_level == "verbose"
+        assert cfg.user_interface is False
+        assert cfg.check_icloud_status is True
+        assert "*.tmp" in cfg.ignore_patterns
+
+    def test_defaults_for_missing_sections(self, tmp_path):
+        path = tmp_path / "empty.yaml"
+        local  = tmp_path / "l"; local.mkdir()
+        icloud = tmp_path / "c"; icloud.mkdir()
+        path.write_text(yaml.dump({"paths": {"local_vault": str(local), "icloud_vault": str(icloud)}}))
+        cfg = SyncConfig.from_yaml(str(path))
+        assert cfg.poll_interval == 2
+        assert cfg.console_level == "normal"
+
+    def test_check_icloud_status_loaded(self, valid_yaml):
+        path, _, _ = valid_yaml
+        cfg = SyncConfig.from_yaml(str(path))
+        assert cfg.check_icloud_status is True
+
+    def test_check_icloud_status_default_true(self, tmp_path):
+        path = tmp_path / "c.yaml"
+        path.write_text(yaml.dump({"sync": {}, "paths": {}}))
+        cfg = SyncConfig.from_yaml(str(path))
+        assert cfg.check_icloud_status is True
+
+    def test_raises_file_not_found(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            SyncConfig.from_yaml(str(tmp_path / "nonexistent.yaml"))
+
+    def test_raises_invalid_yaml(self, tmp_path):
+        path = tmp_path / "bad.yaml"
+        path.write_text("key: [unclosed")
+        with pytest.raises(ValueError, match="invalid YAML"):
+            SyncConfig.from_yaml(str(path))
+
+    def test_handles_empty_yaml(self, tmp_path):
+        path = tmp_path / "empty.yaml"
+        path.write_text("")
+        cfg = SyncConfig.from_yaml(str(path))
+        assert isinstance(cfg, SyncConfig)
+        assert cfg.local_vault == ""
+
+    def test_run_continuously_default(self, tmp_path):
+        path = tmp_path / "c.yaml"; path.write_text("{}")
+        cfg = SyncConfig.from_yaml(str(path))
+        assert cfg.run_continuously is True
+
+# ── validate ──
+
+class TestValidate:
+    def test_valid_config_no_errors(self, cfg):
+        errors = cfg.validate()
+        critical = [e for e in errors if e[1] == "critical"]
+        assert not critical
+
+    def test_empty_local_vault_is_critical(self, cfg):
+        cfg.local_vault = ""
+        errors = cfg.validate()
+        codes = [e[0] for e in errors]
+        assert "path_not_set" in codes
+        severities = {e[0]: e[1] for e in errors}
+        assert severities["path_not_set"] == "critical"
+
+    def test_empty_icloud_vault_is_critical(self, cfg):
+        cfg.icloud_vault = ""
+        errors = cfg.validate()
+        assert any(e[0] == "path_not_set" for e in errors)
+
+    def test_nonexistent_local_vault_is_critical(self, cfg, tmp_path):
+        cfg.local_vault = str(tmp_path / "ghost")
+        errors = cfg.validate()
+        assert any(e[0] == "path_does_not_exist" for e in errors)
+
+    def test_same_local_and_icloud_is_critical(self, cfg):
+        cfg.icloud_vault = cfg.local_vault
+        errors = cfg.validate()
+        assert any(e[0] == "same_paths" for e in errors)
+
+    def test_history_inside_local_vault_is_critical(self, cfg):
+        cfg.history_dir = os.path.join(cfg.local_vault, "history")
+        os.makedirs(cfg.history_dir, exist_ok=True)
+        errors = cfg.validate()
+        assert any(e[0] == "history_dir_inside_vault" for e in errors)
+
+    def test_history_inside_icloud_vault_is_critical(self, cfg):
+        cfg.history_dir = os.path.join(cfg.icloud_vault, "hist")
+        os.makedirs(cfg.history_dir, exist_ok=True)
+        errors = cfg.validate()
+        assert any(e[0] == "history_dir_inside_vault" for e in errors)
+
+    def test_missing_history_dir_is_warn(self, cfg, tmp_path):
+        cfg.history_dir = str(tmp_path / "nonexistent_hist")
+        errors = cfg.validate()
+        warns = [e for e in errors if e[1] == "warn"]
+        assert any(e[0] == "dir_missing" for e in warns)
+
+    def test_suspicious_pattern_is_warn(self, cfg):
+        cfg.ignore_patterns = ["//bad"]
+        errors = cfg.validate()
+        assert any(e[0] == "suspicious_ignore_pattern" for e in errors)
+
+    def test_returns_empty_for_perfect_config(self, cfg):
+        assert cfg.validate() == []
+
+# ── is_ignored ──
+
+class TestIsIgnored:
+    def test_exact_match(self, cfg):
+        cfg.ignore_patterns = ["notes/private.md"]
+        assert cfg.is_ignored("notes/private.md") is True
+
+    def test_glob_wildcard(self, cfg):
+        cfg.ignore_patterns = ["*.canvas"]
+        assert cfg.is_ignored("diagram.canvas") is True
+        assert cfg.is_ignored("diagram.md") is False
+
+    def test_dir_prefix(self, cfg):
+        cfg.ignore_patterns = ["Templates"]
+        assert cfg.is_ignored("Templates/hello.md") is True
+        assert cfg.is_ignored("other/hello.md") is False
+
+    def test_no_match(self, cfg):
+        cfg.ignore_patterns = ["*.tmp"]
+        assert cfg.is_ignored("notes.md") is False
+
+    def test_backslash_normalized(self, cfg):
+        cfg.ignore_patterns = ["notes/private.md"]
+        assert cfg.is_ignored(r"notes\private.md") is True
+
+    def test_case_insensitive(self, cfg):
+        cfg.ignore_patterns = ["*.TMP"]
+        assert cfg.is_ignored("file.tmp") is True
+
+    def test_empty_patterns(self, cfg):
+        cfg.ignore_patterns = []
+        assert cfg.is_ignored("anything.md") is False
+
+# ── disp ──
+
+class TestDisp:
+    def test_short_path_unchanged(self, cfg):
+        cfg.shorter_paths = True
+        assert cfg.disp("note.md") == "note.md"
+
+    def test_absolute_local_path_becomes_relative(self, cfg):
+        cfg.shorter_paths = True
+        p = os.path.join(cfg.local_vault, "note.md")
+        result = cfg.disp(p)
+        assert "note.md" in result
+        assert cfg.local_vault not in result
+
+    def test_absolute_icloud_path_becomes_relative(self, cfg):
+        cfg.shorter_paths = True
+        p = os.path.join(cfg.icloud_vault, "note.md")
+        result = cfg.disp(p)
+        assert "note.md" in result
+        assert cfg.icloud_vault not in result
+
+    def test_long_path_truncated(self, cfg):
+        cfg.shorter_paths = True
+        cfg.max_display_length = 20
+        long_path = "a/b/c/d/e/very_long_name.md"
+        result = cfg.disp(long_path)
+        assert len(result) <= cfg.max_display_length + 3
+
+    def test_shorter_paths_false(self, cfg):
+        cfg.shorter_paths = False
+        p = "/some/absolute/path.md"
+        assert cfg.disp(p) == p
+
+# ── min_seed_size ──
+
+class TestMinSeedSize:
+    def test_obsidian_settings_allow_1_byte(self, cfg):
+        cfg.tiny_threshold = 8
+        assert cfg.min_seed_size(".obsidian/app.json") == 1
+
+    def test_regular_file_uses_tiny_threshold(self, cfg):
+        cfg.tiny_threshold = 8
+        assert cfg.min_seed_size("notes/hello.md") == 8
+
+    def test_nested_obsidian_path(self, cfg):
+        cfg.tiny_threshold = 8
+        assert cfg.min_seed_size(".obsidian/plugins/x/data.json") == 1
+
+# ── state_file_path ──
+
+class TestStateFilePath:
+    def test_returns_path_in_logs_dir(self, cfg):
+        result = cfg.state_file_path
+        assert result.startswith(cfg.logs_dir)
+        assert result.endswith("sync_state.json")

--- a/src/obsidian_sync/tests/test_disk_io.py
+++ b/src/obsidian_sync/tests/test_disk_io.py
@@ -1,0 +1,201 @@
+import os
+import asyncio
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock, call
+from conftest import DiskIO, safe_exists, size_or_zero, safe_mtime, ensure_dir
+
+# ── Safe Exists ──
+
+class TestSafeExists:
+    def test_returns_true_for_existing_file(self, tmp_path):
+        f = tmp_path / "a.txt"; f.write_text("x")
+        assert safe_exists(str(f)) is True
+
+    def test_returns_false_for_missing(self, tmp_path):
+        assert safe_exists(str(tmp_path / "ghost.txt")) is False
+
+    def test_returns_false_on_exception(self):
+        with patch("os.path.exists", side_effect=PermissionError):
+            assert safe_exists("/some/path") is False
+
+# ── Size Or Zero ──
+
+class TestSizeOrZero:
+    def test_returns_file_size(self, tmp_path):
+        f = tmp_path / "a.txt"; f.write_bytes(b"hello")
+        assert size_or_zero(str(f)) == 5
+
+    def test_returns_zero_for_missing(self, tmp_path):
+        assert size_or_zero(str(tmp_path / "ghost.txt")) == 0
+
+    def test_returns_zero_on_exception(self):
+        with patch("os.path.getsize", side_effect=OSError):
+            assert size_or_zero("/some/path") == 0
+
+# ── Safe Mtime ──
+
+class TestSafeMtime:
+    def test_returns_mtime(self, tmp_path):
+        f = tmp_path / "a.txt"; f.write_text("x")
+        assert safe_mtime(str(f)) > 0
+
+    def test_returns_zero_for_missing(self, tmp_path):
+        assert safe_mtime(str(tmp_path / "ghost.txt")) == 0
+
+    def test_returns_zero_on_exception(self):
+        with patch("os.path.getmtime", side_effect=OSError):
+            assert safe_mtime("/path") == 0
+
+# ── Ensure Dir ──
+
+class TestEnsureDir:
+    def test_creates_missing_directory(self, tmp_path):
+        d = tmp_path / "new" / "nested"
+        ensure_dir(str(d))
+        assert d.exists()
+
+    def test_no_error_if_already_exists(self, tmp_path):
+        d = tmp_path / "existing"; d.mkdir()
+        ensure_dir(str(d))
+
+# ── DiskIO ──
+
+class TestDiskIOInit:
+    def test_requires_windows_platform(self, cfg, mock_log):
+        with patch("platform.system", return_value="Linux"):
+            with pytest.raises(RuntimeError, match="Windows"):
+                DiskIO(cfg, mock_log)
+
+    def test_accepts_windows_platform(self, cfg, mock_log):
+        with patch("platform.system", return_value="Windows"):
+            dio = DiskIO(cfg, mock_log)
+            assert dio is not None
+
+# ── Async Copy ──
+
+class TestAsyncCopy:
+    @pytest.mark.asyncio
+    async def test_successful_copy(self, cfg, tmp_path, mock_log):
+        src = tmp_path / "src.md"; src.write_text("content")
+        dst = tmp_path / "dst.md"
+        with patch("platform.system", return_value="Windows"):
+            dio = DiskIO(cfg, mock_log)
+        await dio.async_copy(str(src), str(dst))
+        assert dst.exists()
+        assert dst.read_text() == "content"
+
+    @pytest.mark.asyncio
+    async def test_creates_parent_dirs(self, cfg, tmp_path, mock_log):
+        src = tmp_path / "src.md"; src.write_text("x")
+        dst = tmp_path / "deep" / "path" / "dst.md"
+        with patch("platform.system", return_value="Windows"):
+            dio = DiskIO(cfg, mock_log)
+        await dio.async_copy(str(src), str(dst))
+        assert dst.exists()
+
+    @pytest.mark.asyncio
+    async def test_retries_on_permission_error(self, cfg, tmp_path, mock_log):
+        src = tmp_path / "src.md"; src.write_text("x")
+        dst = tmp_path / "dst.md"
+        call_count = [0]
+        orig_replace = os.replace
+
+        def flaky_replace(s, d):
+            call_count[0] += 1
+            if call_count[0] < 3:
+                raise PermissionError("locked")
+            orig_replace(s, d)
+
+        with patch("platform.system", return_value="Windows"):
+            dio = DiskIO(cfg, mock_log)
+        with patch("os.replace", side_effect=flaky_replace):
+            await dio.async_copy(str(src), str(dst))
+        assert call_count[0] == 3
+
+    @pytest.mark.asyncio
+    async def test_cleans_tmp_on_write_failure(self, cfg, tmp_path, mock_log):
+        src = tmp_path / "src.md"; src.write_text("x")
+        dst = tmp_path / "dst.md"
+        with patch("platform.system", return_value="Windows"):
+            dio = DiskIO(cfg, mock_log)
+        with patch("obsidian_sync.disk_io.shutil.copy2", side_effect=OSError("disk full")):
+            with pytest.raises(OSError):
+                await dio.async_copy(str(src), str(dst))
+        tmp_file = str(dst) + ".tmp"
+        assert not os.path.exists(tmp_file)
+
+# ── Remove File ──
+
+class TestRemoveFile:
+    @pytest.mark.asyncio
+    async def test_removes_existing_file(self, cfg, tmp_path, mock_log):
+        f = tmp_path / "del.md"; f.write_text("x")
+        with patch("platform.system", return_value="Windows"):
+            dio = DiskIO(cfg, mock_log)
+        await dio.remove_file(str(f), "test")
+        assert not f.exists()
+
+    @pytest.mark.asyncio
+    async def test_no_error_if_file_missing(self, cfg, tmp_path, mock_log):
+        with patch("platform.system", return_value="Windows"):
+            dio = DiskIO(cfg, mock_log)
+        await dio.remove_file(str(tmp_path / "ghost.md"), "test")
+        mock_log.error.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_removes_empty_parent_dirs(self, cfg, tmp_path, mock_log):
+        sub = tmp_path / "empty_sub"; sub.mkdir()
+        f = sub / "note.md"; f.write_text("x")
+        cfg.local_vault = str(tmp_path)
+        cfg.icloud_vault = str(tmp_path / "ic")
+        cfg.history_dir = str(tmp_path / "hi")
+        with patch("platform.system", return_value="Windows"):
+            dio = DiskIO(cfg, mock_log)
+        await dio.remove_file(str(f), "test")
+        assert not sub.exists()
+
+# ── Remove File Sync ──
+
+class TestRemoveFileSync:
+    def test_removes_file(self, cfg, tmp_path, mock_log):
+        f = tmp_path / "sync_del.md"; f.write_text("x")
+        with patch("platform.system", return_value="Windows"):
+            dio = DiskIO(cfg, mock_log)
+        dio.remove_file_sync(str(f), "test")
+        assert not f.exists()
+
+    def test_no_error_if_missing(self, cfg, tmp_path, mock_log):
+        with patch("platform.system", return_value="Windows"):
+            dio = DiskIO(cfg, mock_log)
+        dio.remove_file_sync(str(tmp_path / "ghost.md"), "test")
+
+# ── Create Conflict Duplicate ──
+
+class TestCreateConflictDuplicate:
+    @pytest.mark.asyncio
+    async def test_creates_conflict_file(self, cfg, tmp_path, mock_log):
+        f = tmp_path / "note.md"; f.write_text("original")
+        with patch("platform.system", return_value="Windows"):
+            dio = DiskIO(cfg, mock_log)
+        await dio.create_conflict_duplicate(str(f))
+        conflicts = list(tmp_path.glob("*_CONFLICT_*"))
+        assert len(conflicts) == 1
+        assert conflicts[0].read_text() == "original"
+
+    @pytest.mark.asyncio
+    async def test_conflict_preserves_extension(self, cfg, tmp_path, mock_log):
+        f = tmp_path / "note.md"; f.write_text("x")
+        with patch("platform.system", return_value="Windows"):
+            dio = DiskIO(cfg, mock_log)
+        await dio.create_conflict_duplicate(str(f))
+        conflicts = list(tmp_path.glob("*_CONFLICT_*.md"))
+        assert len(conflicts) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_raise_on_copy_failure(self, cfg, tmp_path, mock_log):
+        f = tmp_path / "note.md"; f.write_text("x")
+        with patch("platform.system", return_value="Windows"):
+            dio = DiskIO(cfg, mock_log)
+        with patch("shutil.copy2", side_effect=OSError("fail")):
+            await dio.create_conflict_duplicate(str(f))
+        mock_log.error.assert_called()

--- a/src/obsidian_sync/tests/test_duplicates.py
+++ b/src/obsidian_sync/tests/test_duplicates.py
@@ -1,0 +1,133 @@
+import os
+import pytest
+from unittest.mock import call, patch, MagicMock
+from conftest import DuplicateScanner
+
+@pytest.fixture
+def scanner(cfg, mock_log, mock_disk_io):
+    return DuplicateScanner(cfg, mock_log, mock_disk_io)
+
+# ── No Duplicates ──
+
+class TestNoDuplicates:
+    def test_logs_clean_when_no_duplicates(self, scanner, cfg):
+        (cfg.local_vault_path if hasattr(cfg, 'local_vault_path') else None)
+        with patch("builtins.input", return_value="n"):
+            scanner.scan_and_clean()
+        scanner.log.success.assert_called()
+
+    def test_skips_missing_vaults(self, scanner, cfg):
+        cfg.icloud_vault = "/nonexistent/path"
+        with patch("builtins.input", return_value="n"):
+            scanner.scan_and_clean()
+
+    def test_skips_none_vault(self, scanner, cfg):
+        cfg.history_dir = None
+        with patch("builtins.input", return_value="n"):
+            scanner.scan_and_clean()
+
+# ── Pattern Detection ──
+
+class TestPatternDetection:
+    def _create(self, base_dir, name):
+        p = os.path.join(base_dir, name)
+        with open(p, "w"):
+            pass
+        return p
+
+    def test_detects_conflict_file(self, scanner, cfg):
+        self._create(cfg.local_vault, "note_CONFLICT_20260101_120000_123456.md")
+        found = []
+        with patch("builtins.input", return_value="n") as _:
+            scanner.scan_and_clean()
+        scanner.log.warn.assert_called()
+
+    def test_detects_icloud_duplicate(self, scanner, cfg):
+        self._create(cfg.local_vault, "My Note (1).md")
+        with patch("builtins.input", return_value="n"):
+            scanner.scan_and_clean()
+        scanner.log.warn.assert_called()
+
+    def test_detects_tmp_file(self, scanner, cfg):
+        self._create(cfg.local_vault, "stale.tmp")
+        with patch("builtins.input", return_value="n"):
+            scanner.scan_and_clean()
+        scanner.log.warn.assert_called()
+
+    def test_ignores_trash_directory(self, scanner, cfg):
+        trash = os.path.join(cfg.local_vault, ".trash"); os.makedirs(trash)
+        self._create(trash, "deleted (1).md")
+        scanner.log.warn.reset_mock()
+        scanner.log.error.reset_mock()
+        with patch("builtins.input", return_value="n"):
+            scanner.scan_and_clean()
+        scanner.log.error.assert_not_called()
+        for call in scanner.log.warn.call_args_list:
+            assert "deleted (1).md" not in str(call)
+
+    def test_scans_icloud_vault(self, scanner, cfg):
+        self._create(cfg.icloud_vault, "file_CONFLICT_20260101_120000_000001.md")
+        with patch("builtins.input", return_value="n"):
+            scanner.scan_and_clean()
+        scanner.log.warn.assert_called()
+
+    def test_scans_history_dir(self, scanner, cfg):
+        self._create(cfg.history_dir, "archive (2).md")
+        with patch("builtins.input", return_value="n"):
+            scanner.scan_and_clean()
+        scanner.log.warn.assert_called()
+
+# ── User Interaction ──
+
+class TestUserInteraction:
+    def _create_dup(self, cfg):
+        p = os.path.join(cfg.local_vault, "note_CONFLICT_20260101_120000_000001.md")
+        open(p, "w").close()
+        return p
+
+    def test_user_yes_triggers_deletion(self, scanner, cfg):
+        p = self._create_dup(cfg)
+        with patch("builtins.input", return_value="y"):
+            scanner.scan_and_clean()
+        scanner.io.remove_file_sync.assert_called()
+
+    def test_user_YES_uppercase_triggers_deletion(self, scanner, cfg):
+        self._create_dup(cfg)
+        with patch("builtins.input", return_value="YES"):
+            scanner.scan_and_clean()
+        scanner.io.remove_file_sync.assert_called()
+
+    def test_user_no_skips_deletion(self, scanner, cfg):
+        self._create_dup(cfg)
+        with patch("builtins.input", return_value="n"):
+            scanner.scan_and_clean()
+        scanner.io.remove_file_sync.assert_not_called()
+
+    def test_user_empty_skips_deletion(self, scanner, cfg):
+        self._create_dup(cfg)
+        with patch("builtins.input", return_value=""):
+            scanner.scan_and_clean()
+        scanner.io.remove_file_sync.assert_not_called()
+
+    def test_all_removed_logs_success(self, scanner, cfg):
+        p = self._create_dup(cfg)
+        scanner.io.remove_file_sync.side_effect = lambda path, label: os.remove(path)
+        with patch("builtins.input", return_value="y"):
+            scanner.scan_and_clean()
+        scanner.log.success.assert_called()
+
+    def test_partial_failure_logs_error(self, scanner, cfg):
+        self._create_dup(cfg)
+        scanner.io.remove_file_sync.return_value = None
+        with patch("builtins.input", return_value="y"):
+            scanner.scan_and_clean()
+        scanner.log.error.assert_called()
+
+    def test_count_in_error_message(self, scanner, cfg):
+        for i in range(3):
+            p = os.path.join(cfg.local_vault, f"note_CONFLICT_20260101_12000{i}_00000{i}.md")
+            open(p, "w").close()
+        with patch("builtins.input", return_value="n"):
+            scanner.scan_and_clean()
+        err_args = scanner.log.error.call_args_list[0][0]
+        assert "3" in str(err_args)

--- a/src/obsidian_sync/tests/test_hasher.py
+++ b/src/obsidian_sync/tests/test_hasher.py
@@ -1,0 +1,170 @@
+import os
+import json
+import hashlib
+import asyncio
+import pytest
+import aiofiles
+from unittest.mock import patch, MagicMock, AsyncMock
+from conftest import FileHasher
+
+# ── Load State ──
+
+class TestLoadState:
+    def test_empty_state_if_no_file(self, hasher):
+        hasher.load_state()
+        assert hasher.state == {}
+
+    def test_loads_valid_state(self, hasher, cfg):
+        data = {"note.md": {"L": {"mtime": 1.0, "size": 10, "hash": "abc"}}}
+        path = cfg.state_file_path
+        with open(path, "w") as f:
+            json.dump(data, f)
+        hasher.load_state()
+        assert "note.md" in hasher.state
+
+    def test_handles_corrupt_json(self, hasher, cfg):
+        path = cfg.state_file_path
+        with open(path, "w") as f:
+            f.write("{invalid json}")
+        hasher.load_state()
+        assert hasher.state == {}
+
+    def test_creates_backup_of_corrupt_file(self, hasher, cfg):
+        path = cfg.state_file_path
+        with open(path, "w") as f:
+            f.write("{invalid}")
+        hasher.load_state()
+        assert os.path.exists(path + ".corrupt")
+
+# ── Save State ──
+
+class TestSaveState:
+    def test_saves_state_to_file(self, hasher, cfg):
+        hasher.state = {"note.md": {"L": {"mtime": 1.0, "size": 5, "hash": "abc"}}}
+        hasher.save_state()
+        assert os.path.exists(cfg.state_file_path)
+        with open(cfg.state_file_path) as f:
+            loaded = json.load(f)
+        assert "note.md" in loaded
+
+    def test_removes_empty_entries(self, hasher, cfg):
+        hasher.state = {"note.md": {}, "other.md": {"L": {"hash": "x"}}}
+        hasher.save_state()
+        with open(cfg.state_file_path) as f:
+            loaded = json.load(f)
+        assert "note.md" not in loaded
+
+    def test_clears_dirty_flag(self, hasher, cfg):
+        hasher.state = {"a.md": {"L": {"mtime": 1.0, "size": 1, "hash": "x"}}}
+        hasher.dirty = True
+        hasher.save_state()
+        assert hasher.dirty is False
+
+    def test_atomic_write_via_tmp(self, hasher, cfg):
+        hasher.state = {"f.md": {"L": {"mtime": 1.0, "size": 1, "hash": "x"}}}
+        with patch("os.replace") as mock_replace:
+            hasher.save_state()
+            mock_replace.assert_called_once()
+            args = mock_replace.call_args[0]
+            assert args[0].endswith(".tmp")
+
+# ── Hash File ──
+
+class TestHashFile:
+    @pytest.mark.asyncio
+    async def test_hashes_file_content(self, hasher, tmp_path):
+        f = tmp_path / "note.md"
+        f.write_bytes(b"hello world")
+        result = await hasher.hash_file(str(f))
+        expected = hashlib.sha256(b"hello world").hexdigest()
+        assert result == expected
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_missing_file(self, hasher, tmp_path):
+        result = await hasher.hash_file(str(tmp_path / "ghost.md"))
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_retries_on_permission_error(self, hasher, tmp_path):
+        f = tmp_path / "locked.md"; f.write_text("x")
+        call_count = [0]
+        real_open = aiofiles.open
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=AsyncMock(read=AsyncMock(side_effect=lambda size=-1: b"x")))
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+        def flaky_open(path, mode="rb", **kwargs):
+            call_count[0] += 1
+            if call_count[0] < 3:
+                raise PermissionError("locked")
+            return real_open(path, mode, **kwargs)
+        with patch("aiofiles.open", side_effect=flaky_open):
+            result = await hasher.hash_file(str(f))
+        assert call_count[0] == 3
+
+    @pytest.mark.asyncio
+    async def test_returns_none_after_max_retries(self, hasher, tmp_path):
+        f = tmp_path / "locked.md"; f.write_text("x")
+        with patch("aiofiles.open", side_effect=PermissionError("always locked")):
+            result = await hasher.hash_file(str(f))
+        assert result is None
+
+# ── Get Cached Hash ──
+
+class TestGetCachedHash:
+    def _put_cache(self, hasher, rel, side, mtime, size, hash_val):
+        hasher.state.setdefault(rel, {})[side] = {
+            "mtime": mtime, "size": size, "hash": hash_val
+        }
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_returns_cached_hash(self, hasher, tmp_path, cfg):
+        f = tmp_path / "note.md"; f.write_bytes(b"content")
+        mtime = os.path.getmtime(str(f))
+        size  = os.path.getsize(str(f))
+        self._put_cache(hasher, "note.md", "L", mtime, size, "cached_hash")
+        result = await hasher.get_cached_hash(str(f), "L", "note.md")
+        assert result == "cached_hash"
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_rehashes(self, hasher, tmp_path):
+        f = tmp_path / "note.md"; f.write_bytes(b"hello")
+        expected = hashlib.sha256(b"hello").hexdigest()
+        self._put_cache(hasher, "note.md", "L", 0.0, 0, "old_hash")
+        result = await hasher.get_cached_hash(str(f), "L", "note.md")
+        assert result == expected
+
+    @pytest.mark.asyncio
+    async def test_force_bypasses_cache(self, hasher, tmp_path):
+        f = tmp_path / "note.md"; f.write_bytes(b"hello")
+        mtime = os.path.getmtime(str(f))
+        size  = os.path.getsize(str(f))
+        self._put_cache(hasher, "note.md", "L", mtime, size, "cached_hash")
+        expected = hashlib.sha256(b"hello").hexdigest()
+        result = await hasher.get_cached_hash(str(f), "L", "note.md", force=True)
+        assert result == expected
+
+    @pytest.mark.asyncio
+    async def test_missing_file_returns_none(self, hasher, tmp_path):
+        result = await hasher.get_cached_hash(str(tmp_path / "ghost.md"), "L", "ghost.md")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_missing_file_cleans_cache(self, hasher, tmp_path):
+        self._put_cache(hasher, "gone.md", "L", 1.0, 10, "old")
+        await hasher.get_cached_hash(str(tmp_path / "gone.md"), "L", "gone.md")
+        assert "L" not in hasher.state.get("gone.md", {})
+
+    @pytest.mark.asyncio
+    async def test_updates_cache_after_rehash(self, hasher, tmp_path):
+        f = tmp_path / "note.md"; f.write_bytes(b"data")
+        await hasher.get_cached_hash(str(f), "L", "note.md")
+        assert "note.md" in hasher.state
+        assert "L" in hasher.state["note.md"]
+        assert "hash" in hasher.state["note.md"]["L"]
+
+    @pytest.mark.asyncio
+    async def test_rehash_marks_dirty(self, hasher, tmp_path):
+        f = tmp_path / "note.md"; f.write_bytes(b"data")
+        hasher.dirty = False
+        await hasher.get_cached_hash(str(f), "L", "note.md")
+        assert hasher.dirty is True

--- a/src/obsidian_sync/tests/test_icloud_status.py
+++ b/src/obsidian_sync/tests/test_icloud_status.py
@@ -1,0 +1,110 @@
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+from conftest import (FILE_ATTRIBUTE_PINNED, FILE_ATTRIBUTE_OFFLINE, FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS,ICloudStatusChecker, ICloudSyncState)
+
+# ── Fixtures ──
+
+@pytest.fixture
+def checker():
+    with patch("platform.system", return_value="Windows"):
+        c = ICloudStatusChecker()
+    mock_k32 = MagicMock()
+    mock_k32.GetFileAttributesW.return_value = 0x00000020
+    mock_k32.GetFileAttributesW.argtypes = None
+    mock_k32.GetFileAttributesW.restype = None
+    c._k32 = mock_k32
+    c._available = True
+    return c
+
+# ── ICloudSyncState ──
+
+class TestSyncStateIsSafe:
+    def test_local_is_safe(self):
+        assert ICloudSyncState.LOCAL.is_safe is True
+
+    def test_pinned_is_safe(self):
+        assert ICloudSyncState.PINNED.is_safe is True
+
+    def test_cloud_only_not_safe(self):
+        assert ICloudSyncState.CLOUD_ONLY.is_safe is False
+
+    def test_downloading_not_safe(self):
+        assert ICloudSyncState.DOWNLOADING.is_safe is False
+
+    def test_unknown_enum_not_safe(self):
+        assert ICloudSyncState.UNKNOWN.is_safe is False
+
+    def test_all_states_have_status(self):
+        for state in ICloudSyncState:
+            assert hasattr(state, "status"), f"{state} missing status attribute"
+            assert isinstance(state.status, str)
+            assert len(state.status) > 0
+
+# ── ICloudStatusChecker ──
+
+class TestDetect:
+    def test_local_no_cloud_flags(self, checker):
+        checker._k32.GetFileAttributesW.return_value = 0x00000020
+        assert checker.detect("C:/fake/file.md") == ICloudSyncState.LOCAL
+
+    def test_pinned(self, checker):
+        checker._k32.GetFileAttributesW.return_value = FILE_ATTRIBUTE_PINNED
+        assert checker.detect("C:/fake/file.md") == ICloudSyncState.PINNED
+
+    def test_cloud_only_via_offline(self, checker):
+        checker._k32.GetFileAttributesW.return_value = FILE_ATTRIBUTE_OFFLINE
+        assert checker.detect("C:/fake/file.md") == ICloudSyncState.CLOUD_ONLY
+
+    def test_cloud_only_via_recall(self, checker):
+        checker._k32.GetFileAttributesW.return_value = FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS
+        assert checker.detect("C:/fake/file.md") == ICloudSyncState.CLOUD_ONLY
+
+    def test_downloading_offline_plus_pinned(self, checker):
+        checker._k32.GetFileAttributesW.return_value = FILE_ATTRIBUTE_OFFLINE | FILE_ATTRIBUTE_PINNED
+        assert checker.detect("C:/fake/file.md") == ICloudSyncState.DOWNLOADING
+
+    def test_invalid_file_attributes_returns_unknown(self, checker):
+        checker._k32.GetFileAttributesW.return_value = 0xFFFFFFFF
+        assert checker.detect("C:/fake/file.md") == ICloudSyncState.UNKNOWN
+
+    def test_winapi_exception_returns_unknown(self, checker):
+        checker._k32.GetFileAttributesW.side_effect = OSError("WinAPI crash")
+        assert checker.detect("C:/fake/file.md") == ICloudSyncState.UNKNOWN
+
+    def test_unavailable_checker_returns_unknown(self):
+        with patch("platform.system", return_value="Linux"):
+            c = ICloudStatusChecker()
+            assert c.detect("C:/fake/file.md") == ICloudSyncState.UNKNOWN
+
+# ── Is Safe ──
+
+class TestIsSafe:
+    def test_local_is_safe(self, checker):
+        checker._k32.GetFileAttributesW.return_value = 0x00000020
+        assert checker.is_safe("C:/fake/file.md") is True
+
+    def test_pinned_is_safe(self, checker):
+        checker._k32.GetFileAttributesW.return_value = FILE_ATTRIBUTE_PINNED
+        assert checker.is_safe("C:/fake/file.md") is True
+
+    def test_cloud_only_is_not_safe(self, checker):
+        checker._k32.GetFileAttributesW.return_value = FILE_ATTRIBUTE_OFFLINE
+        assert checker.is_safe("C:/fake/file.md") is False
+
+    def test_downloading_is_not_safe(self, checker):
+        checker._k32.GetFileAttributesW.return_value = FILE_ATTRIBUTE_OFFLINE | FILE_ATTRIBUTE_PINNED
+        assert checker.is_safe("C:/fake/file.md") is False
+
+    def test_unknown_is_safe_fail_open(self, checker):
+        checker._k32.GetFileAttributesW.return_value = 0xFFFFFFFF
+        assert checker.is_safe("C:/fake/file.md") is True
+
+    def test_unavailable_platform_is_safe(self):
+        with patch("platform.system", return_value="Darwin"):
+            c = ICloudStatusChecker()
+            assert c.is_safe("C:/fake/file.md") is True
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--tb=short"])

--- a/src/obsidian_sync/tests/test_logger.py
+++ b/src/obsidian_sync/tests/test_logger.py
@@ -1,0 +1,248 @@
+import os
+import asyncio
+import pytest
+import time
+from unittest.mock import patch, MagicMock
+from conftest import SyncLogger, strip_ansi, colored, LEVEL_MAP
+from colorama import Fore, Style
+
+# ── Helpers ──
+
+class TestHelpers:
+    def test_strip_ansi_removes_codes(self):
+        raw = "\x1b[32mGREEN\x1b[0m text"
+        assert strip_ansi(raw) == "GREEN text"
+
+    def test_strip_ansi_plain_text_unchanged(self):
+        assert strip_ansi("hello world") == "hello world"
+
+    def test_strip_ansi_empty_string(self):
+        assert strip_ansi("") == ""
+
+    def test_colored_wraps_in_codes(self):
+        result = colored("hello", Fore.RED)
+        assert "hello" in result
+        assert Style.RESET_ALL in result
+
+    def test_level_map_ordering(self):
+        assert LEVEL_MAP["quiet"] < LEVEL_MAP["normal"]
+        assert LEVEL_MAP["normal"] < LEVEL_MAP["verbose"]
+
+# ── console_event ──
+
+class TestConsoleEvent:
+    def _logger(self, cfg, level="normal"):
+        cfg.console_level = level
+        return SyncLogger(cfg)
+
+    def test_important_always_prints(self, cfg, capsys):
+        cfg.console_level = "quiet"
+        log = SyncLogger(cfg)
+        log.console_event("🔵", Fore.CYAN, "TEST", "msg", level="important")
+        assert "msg" in capsys.readouterr().out
+
+    def test_quiet_suppresses_normal(self, cfg, capsys):
+        cfg.console_level = "quiet"
+        log = SyncLogger(cfg)
+        log.console_event("🔵", Fore.CYAN, "TEST", "msg", level="normal")
+        assert capsys.readouterr().out == ""
+
+    def test_quiet_suppresses_verbose(self, cfg, capsys):
+        cfg.console_level = "quiet"
+        log = SyncLogger(cfg)
+        log.console_event("🔵", Fore.CYAN, "TEST", "msg", level="verbose")
+        assert capsys.readouterr().out == ""
+
+    def test_normal_shows_normal_events(self, cfg, capsys):
+        cfg.console_level = "normal"
+        log = SyncLogger(cfg)
+        log.console_event("🔵", Fore.CYAN, "TEST", "msg", level="normal")
+        assert "msg" in capsys.readouterr().out
+
+    def test_normal_suppresses_verbose(self, cfg, capsys):
+        cfg.console_level = "normal"
+        log = SyncLogger(cfg)
+        log.console_event("🔵", Fore.CYAN, "TEST", "msg", level="verbose")
+        assert capsys.readouterr().out == ""
+
+    def test_verbose_shows_all(self, cfg, capsys):
+        cfg.console_level = "verbose"
+        log = SyncLogger(cfg)
+        log.console_event("🔵", Fore.CYAN, "TEST", "msg", level="verbose")
+        assert "msg" in capsys.readouterr().out
+
+# ── write_to_file, flush ──
+
+class TestFileLogging:
+    def test_no_log_file_skips_buffering(self, cfg):
+        log = SyncLogger(cfg)
+        log.log_file = None
+        log.write_to_file("INFO", "hello")
+        assert log._buffer == []
+
+    def test_adds_to_buffer(self, cfg):
+        log = SyncLogger(cfg)
+        log.log_file = str(cfg.logs_dir) + "/test.log"
+        log.write_to_file("INFO", "hello")
+        assert len(log._buffer) == 1
+        assert "hello" in log._buffer[0]
+
+    def test_strips_ansi_in_buffer(self, cfg):
+        log = SyncLogger(cfg)
+        log.log_file = str(cfg.logs_dir) + "/test.log"
+        log.write_to_file("INFO", colored("hello", Fore.GREEN))
+        assert "\x1b" not in log._buffer[0]
+
+    def test_auto_flush_at_20(self, cfg, tmp_path):
+        log = SyncLogger(cfg)
+        log_path = str(tmp_path / "autoflush.log")
+        log.log_file = log_path
+        for i in range(20):
+            log.write_to_file("X", f"msg{i}")
+        assert log._buffer == []
+        assert os.path.exists(log_path)
+
+    def test_flush_writes_to_file(self, cfg, tmp_path):
+        log = SyncLogger(cfg)
+        log_path = str(tmp_path / "flush.log")
+        log.log_file = log_path
+        log._buffer = ["[ts] [INFO] hello\n"]
+        log.flush()
+        content = open(log_path).read()
+        assert "hello" in content
+        assert log._buffer == []
+
+    def test_flush_empty_buffer_is_noop(self, cfg, tmp_path):
+        log = SyncLogger(cfg)
+        log.log_file = str(tmp_path / "noop.log")
+        log._buffer = []
+        log.flush()
+        assert not os.path.exists(str(tmp_path / "noop.log"))
+
+    def test_flush_no_log_file_is_noop(self, cfg):
+        log = SyncLogger(cfg)
+        log.log_file = None
+        log._buffer = ["data"]
+        log.flush()
+        assert log._buffer == ["data"]
+
+# ── Log Methods ──
+
+class TestLogMethods:
+    @pytest.fixture
+    def log(self, cfg):
+        l = SyncLogger(cfg)
+        l.log_file = str(cfg.logs_dir) + "/test.log"
+        return l
+
+    def test_info_calls_console_and_file(self, log):
+        with patch.object(log, "console_event") as ce, \
+             patch.object(log, "write_to_file") as wf:
+            log.info("INFO", "test msg", level="verbose")
+            ce.assert_called_once()
+            wf.assert_called_once_with("INFO", "test msg")
+
+    def test_warn_calls_console_and_file(self, log):
+        with patch.object(log, "console_event") as ce, \
+             patch.object(log, "write_to_file") as wf:
+            log.warn("WARN", "warning")
+            ce.assert_called_once()
+            wf.assert_called_once()
+
+    def test_error_calls_console_and_file(self, log):
+        with patch.object(log, "console_event") as ce, \
+             patch.object(log, "write_to_file") as wf:
+            log.error("ERR", "error msg")
+            ce.assert_called_once()
+            wf.assert_called_once()
+
+    def test_success_calls_console_and_file(self, log):
+        with patch.object(log, "console_event") as ce, \
+             patch.object(log, "write_to_file") as wf:
+            log.success("OK", "done")
+            ce.assert_called_once()
+            wf.assert_called_once()
+
+    def test_error_critical_exits(self, log):
+        with patch.object(log, "flush"), \
+             pytest.raises(SystemExit) as exc_info:
+            log.error("CRITICAL", "fatal", critical=True)
+        assert exc_info.value.code == 1
+
+    def test_custom_verbose_uses_full_msg(self, log, cfg, capsys):
+        cfg.console_level = "verbose"
+        log.custom(["→", "🔵"], [Fore.GREEN, Fore.CYAN], "PUSH", "Full detailed message", "short.md", level="verbose")
+        out = capsys.readouterr().out
+        assert "Full detailed message" in out
+
+    def test_custom_normal_uses_short_path(self, log, cfg, capsys):
+        cfg.console_level = "normal"
+        log.custom(["→", "🔵"], [Fore.GREEN, Fore.CYAN], "PUSH", "Full detailed message", "short.md", level="normal")
+        out = capsys.readouterr().out
+        assert "short.md" in out
+        assert "Full detailed message" not in out
+
+# ── init_log_file ──
+
+class TestInitLogFile:
+    def test_sets_log_file_with_timestamp(self, cfg):
+        log = SyncLogger(cfg)
+        log.init_log_file()
+        assert log.log_file is not None
+        assert "sync_" in log.log_file
+        assert log.log_file.endswith(".log")
+        assert log.log_file.startswith(cfg.logs_dir)
+        assert os.path.exists(os.path.dirname(log.log_file))
+
+# ── list_log_files ──
+
+class TestListLogFiles:
+    def test_returns_sorted_by_mtime(self, cfg, tmp_path):
+        log = SyncLogger(cfg)
+        a = tmp_path / "sync_a.log"; a.write_text("a"); time.sleep(0.01)
+        b = tmp_path / "sync_b.log"; b.write_text("b")
+        result = log.list_log_files(str(tmp_path))
+        assert result[-1].endswith("sync_b.log")
+
+    def test_returns_empty_for_missing_dir(self, cfg, tmp_path):
+        log = SyncLogger(cfg)
+        result = log.list_log_files(str(tmp_path / "nonexistent"))
+        assert result == []
+
+    def test_filters_only_log_files(self, cfg, tmp_path):
+        (tmp_path / "file.txt").write_text("x")
+        (tmp_path / "sync.log").write_text("y")
+        log = SyncLogger(cfg)
+        result = log.list_log_files(str(tmp_path))
+        assert all(f.endswith(".log") for f in result)
+
+# ── cleanup_old_logs ──
+
+class TestCleanupOldLogs:
+    @pytest.mark.asyncio
+    async def test_removes_old_logs_beyond_retention(self, cfg, tmp_path):
+        cfg.logs_dir = str(tmp_path)
+        cfg.log_retention = 2
+        for i in range(4):
+            (tmp_path / f"sync_{i:03d}.log").write_text(f"log{i}")
+            time.sleep(0.01)
+        log = SyncLogger(cfg)
+        await log.cleanup_old_logs()
+        remaining = list(tmp_path.glob("*.log"))
+        assert len(remaining) == 2
+
+    @pytest.mark.asyncio
+    async def test_keeps_at_least_1_log(self, cfg, tmp_path):
+        cfg.logs_dir = str(tmp_path)
+        cfg.log_retention = 0
+        (tmp_path / "sync_1.log").write_text("x")
+        log = SyncLogger(cfg)
+        await log.cleanup_old_logs()
+        remaining = list(tmp_path.glob("*.log"))
+        assert len(remaining) >= 1
+
+    @pytest.mark.asyncio
+    async def test_no_error_when_no_logs(self, cfg, tmp_path):
+        cfg.logs_dir = str(tmp_path)
+        log = SyncLogger(cfg)
+        await log.cleanup_old_logs()

--- a/src/obsidian_sync/tests/test_sync_engine.py
+++ b/src/obsidian_sync/tests/test_sync_engine.py
@@ -1,0 +1,480 @@
+import os
+import time
+import asyncio
+import shutil
+import hashlib
+import pytest
+from obsidian_sync.disk_io import DiskIO
+from unittest.mock import patch, MagicMock, AsyncMock, call
+from conftest import SyncEngine, FileHasher, ICloudSyncState, ICloudStatusChecker, DiskIO
+
+# ── Fixtures ──
+
+@pytest.fixture
+def eng(cfg, mock_log, tmp_path):
+    with patch("platform.system", return_value="Windows"):
+        real_io = DiskIO(cfg, mock_log)
+    h   = FileHasher(cfg, mock_log)
+    dup = MagicMock()
+    return SyncEngine(cfg, mock_log, h, real_io, dup)
+
+def _write(path: str, content: str = "content"):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)
+    return path
+
+def _local(cfg, rel): return os.path.join(cfg.local_vault,  rel)
+def _icloud(cfg, rel): return os.path.join(cfg.icloud_vault, rel)
+def _history(cfg, rel): return os.path.join(cfg.history_dir,  rel)
+
+# ── Init ──
+
+class TestInit:
+    def test_checker_created_when_enabled(self, cfg, mock_log):
+        cfg.check_icloud_status = True
+        with patch("platform.system", return_value="Windows"):
+            io = DiskIO(cfg, mock_log)
+            eng = SyncEngine(cfg, mock_log, MagicMock(), io, MagicMock())
+        assert eng.icloud_checker is not None
+
+    def test_checker_none_when_disabled(self, cfg, mock_log):
+        cfg.check_icloud_status = False
+        with patch("platform.system", return_value="Windows"):
+            io = DiskIO(cfg, mock_log)
+            eng = SyncEngine(cfg, mock_log, MagicMock(), io, MagicMock())
+        assert eng.icloud_checker is None
+
+# ── gather_rel_paths ──
+
+class TestGatherRelPaths:
+    @pytest.mark.asyncio
+    async def test_collects_files_from_local(self, eng, cfg):
+        _write(_local(cfg, "a.md"))
+        _write(_local(cfg, "b.md"))
+        paths = eng.gather_rel_paths()
+        assert "a.md" in paths
+        assert "b.md" in paths
+
+    @pytest.mark.asyncio
+    async def test_collects_files_from_icloud(self, eng, cfg):
+        _write(_icloud(cfg, "c.md"))
+        paths = eng.gather_rel_paths()
+        assert "c.md" in paths
+
+    @pytest.mark.asyncio
+    async def test_deduplicates_across_vaults(self, eng, cfg):
+        _write(_local(cfg, "same.md"))
+        _write(_icloud(cfg, "same.md"))
+        paths = eng.gather_rel_paths()
+        assert "same.md" in paths
+
+    @pytest.mark.asyncio
+    async def test_filters_tmp_files(self, eng, cfg):
+        _write(_local(cfg, "draft.tmp"))
+        paths = eng.gather_rel_paths()
+        assert "draft.tmp" not in paths
+
+    @pytest.mark.asyncio
+    async def test_filters_dotunderscore_files(self, eng, cfg):
+        _write(_local(cfg, "._something.md"))
+        paths = eng.gather_rel_paths()
+        assert all("._" not in p for p in paths)
+
+    @pytest.mark.asyncio
+    async def test_filters_page_preview(self, eng, cfg):
+        _write(_local(cfg, "page-preview.md"))
+        paths = eng.gather_rel_paths()
+        assert "page-preview.md" not in paths
+
+    @pytest.mark.asyncio
+    async def test_filters_ignored_patterns(self, eng, cfg):
+        cfg.ignore_patterns = ["private/*.md"]
+        os.makedirs(os.path.join(cfg.local_vault, "private"), exist_ok=True)
+        _write(_local(cfg, "private/secret.md"))
+        paths = eng.gather_rel_paths()
+        assert os.path.normpath("private/secret.md") not in paths
+
+    @pytest.mark.asyncio
+    async def test_filters_ignored_dirs(self, eng, cfg):
+        cfg.ignored_dirs = [".git"]
+        os.makedirs(os.path.join(cfg.local_vault, ".git"), exist_ok=True)
+        _write(_local(cfg, ".git/HEAD"))
+        paths = eng.gather_rel_paths()
+        assert ".git/HEAD" not in paths
+
+    @pytest.mark.asyncio
+    async def test_handles_empty_vaults(self, eng, cfg):
+        paths = eng.gather_rel_paths()
+        assert isinstance(paths, (list, set))
+        assert len(paths) == 0
+
+# ── sync_file L/C/H ──
+
+class TestSyncFileStates:
+    @pytest.mark.asyncio
+    async def test_all_missing_does_nothing(self, eng, cfg):
+        await eng.sync_file("ghost.md")
+        eng.log.success.assert_not_called()
+        eng.log.error.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_only_history_cleans_it_up(self, eng, cfg):
+        _write(_history(cfg, "orphan.md"))
+        await eng.sync_file("orphan.md")
+        assert not os.path.exists(_history(cfg, "orphan.md"))
+
+    @pytest.mark.asyncio
+    async def test_local_only_pushes_to_icloud(self, eng, cfg):
+        _write(_local(cfg, "new.md"), "fresh content")
+        await eng.sync_file("new.md")
+        assert os.path.exists(_icloud(cfg, "new.md"))
+        assert os.path.exists(_history(cfg, "new.md"))
+
+    @pytest.mark.asyncio
+    async def test_icloud_only_pulls_to_local(self, eng, cfg):
+        _write(_icloud(cfg, "remote.md"), "from cloud")
+        await eng.sync_file("remote.md")
+        assert os.path.exists(_local(cfg, "remote.md"))
+        assert os.path.exists(_history(cfg, "remote.md"))
+
+    @pytest.mark.asyncio
+    async def test_identical_l_and_c_no_h_seeds_history(self, eng, cfg):
+        content = "same content"
+        _write(_local(cfg, "sync.md"), content)
+        _write(_icloud(cfg, "sync.md"), content)
+        await eng.sync_file("sync.md")
+        assert os.path.exists(_history(cfg, "sync.md"))
+
+    @pytest.mark.asyncio
+    async def test_identical_l_c_h_skips(self, eng, cfg):
+        content = "stable content"
+        for f in (_local(cfg, "stable.md"), _icloud(cfg, "stable.md"), _history(cfg, "stable.md")):
+            _write(f, content)
+        h = hashlib.sha256(content.encode()).hexdigest()
+        eng.hasher.state["stable.md"] = {
+            "L": {"mtime": os.path.getmtime(_local(cfg, "stable.md")), "size": os.path.getsize(_local(cfg, "stable.md")), "hash": h},
+            "C": {"mtime": os.path.getmtime(_icloud(cfg, "stable.md")), "size": os.path.getsize(_icloud(cfg, "stable.md")), "hash": h},
+            "H": {"mtime": os.path.getmtime(_history(cfg, "stable.md")), "size": os.path.getsize(_history(cfg, "stable.md")), "hash": h},
+        }
+        eng.log.success.reset_mock()
+        await eng.sync_file("stable.md")
+        content_icloud = open(_icloud(cfg, "stable.md")).read()
+        content_local = open(_local(cfg, "stable.md")).read()
+        assert content_icloud == "stable content"
+        assert content_local == "stable content"
+
+    @pytest.mark.asyncio
+    async def test_local_changed_pushes(self, eng, cfg):
+        old = "old content"
+        new = "new local content"
+        for f in (_local(cfg, "mod.md"), _icloud(cfg, "mod.md"), _history(cfg, "mod.md")):
+            _write(f, old)
+        h = hashlib.sha256(old.encode()).hexdigest()
+        old_mtime = os.path.getmtime(_history(cfg, "mod.md"))
+        eng.hasher.state["mod.md"] = {
+            "L": {"mtime": old_mtime, "size": len(old), "hash": h},
+            "C": {"mtime": old_mtime, "size": len(old), "hash": h},
+            "H": {"mtime": old_mtime, "size": len(old), "hash": h},
+        }
+        time.sleep(0.01)
+        _write(_local(cfg, "mod.md"), new)
+        await eng.sync_file("mod.md")
+        assert open(_icloud(cfg, "mod.md")).read() == new
+
+    @pytest.mark.asyncio
+    async def test_icloud_changed_pulls(self, eng, cfg):
+        old = "shared base"
+        new_cloud = "new icloud content"
+        for f in (_local(cfg, "pull.md"), _icloud(cfg, "pull.md"), _history(cfg, "pull.md")):
+            _write(f, old)
+        h = hashlib.sha256(old.encode()).hexdigest()
+        old_mtime = os.path.getmtime(_local(cfg, "pull.md"))
+        eng.hasher.state["pull.md"] = {
+            "L": {"mtime": old_mtime, "size": len(old), "hash": h},
+            "C": {"mtime": old_mtime, "size": len(old), "hash": h},
+            "H": {"mtime": old_mtime, "size": len(old), "hash": h},
+        }
+        time.sleep(0.01)
+        _write(_icloud(cfg, "pull.md"), new_cloud)
+        await eng.sync_file("pull.md")
+        assert open(_local(cfg, "pull.md")).read() == new_cloud
+
+    @pytest.mark.asyncio
+    async def test_both_changed_conflict_resolves(self, eng, cfg):
+        base = "base version"
+        local_new = "local changed"
+        cloud_new = "cloud changed"
+        for f in (_local(cfg, "conflict.md"), _icloud(cfg, "conflict.md"), _history(cfg, "conflict.md")):
+            _write(f, base)
+        h = hashlib.sha256(base.encode()).hexdigest()
+        old_t = os.path.getmtime(_history(cfg, "conflict.md"))
+        eng.hasher.state["conflict.md"] = {
+            "L": {"mtime": old_t, "size": len(base), "hash": h},
+            "C": {"mtime": old_t, "size": len(base), "hash": h},
+            "H": {"mtime": old_t, "size": len(base), "hash": h},
+        }
+        time.sleep(0.01)
+        _write(_local(cfg, "conflict.md"), local_new)
+        time.sleep(0.01)
+        _write(_icloud(cfg, "conflict.md"), cloud_new)
+        await eng.sync_file("conflict.md")
+        content = open(_local(cfg, "conflict.md")).read()
+        assert content == cloud_new
+
+    @pytest.mark.asyncio
+    async def test_user_deleted_local_removes_everywhere(self, eng, cfg):
+        old = "to delete"
+        for f in (_icloud(cfg, "del.md"), _history(cfg, "del.md")):
+            _write(f, old)
+        h = hashlib.sha256(old.encode()).hexdigest()
+        t = os.path.getmtime(_icloud(cfg, "del.md"))
+        eng.hasher.state["del.md"] = {
+            "C": {"mtime": t, "size": len(old), "hash": h},
+            "H": {"mtime": t, "size": len(old), "hash": h},
+        }
+        await eng.sync_file("del.md")
+        assert not os.path.exists(_icloud(cfg, "del.md"))
+        assert not os.path.exists(_history(cfg, "del.md"))
+
+    @pytest.mark.asyncio
+    async def test_user_deleted_icloud_removes_everywhere(self, eng, cfg):
+        old = "to delete"
+        for f in (_local(cfg, "del2.md"), _history(cfg, "del2.md")):
+            _write(f, old)
+        h = hashlib.sha256(old.encode()).hexdigest()
+        t = os.path.getmtime(_local(cfg, "del2.md"))
+        eng.hasher.state["del2.md"] = {
+            "L": {"mtime": t, "size": len(old), "hash": h},
+            "H": {"mtime": t, "size": len(old), "hash": h},
+        }
+        await eng.sync_file("del2.md")
+        assert not os.path.exists(_local(cfg, "del2.md"))
+        assert not os.path.exists(_history(cfg, "del2.md"))
+
+    @pytest.mark.asyncio
+    async def test_no_local_but_icloud_changed_restores(self, eng, cfg):
+        old = "shared base"
+        new = "cloud updated"
+        _write(_history(cfg, "restore.md"), old)
+        _write(_icloud(cfg, "restore.md"), new)
+        h_old = hashlib.sha256(old.encode()).hexdigest()
+        t = os.path.getmtime(_history(cfg, "restore.md"))
+        eng.hasher.state["restore.md"] = {
+            "H": {"mtime": t, "size": len(old), "hash": h_old},
+        }
+        await eng.sync_file("restore.md")
+        assert os.path.exists(_local(cfg, "restore.md"))
+
+    @pytest.mark.asyncio
+    async def test_no_icloud_but_local_changed_pushes(self, eng, cfg):
+        old = "shared base"
+        new = "local updated"
+        _write(_history(cfg, "push2.md"), old)
+        _write(_local(cfg, "push2.md"), new)
+        h_old = hashlib.sha256(old.encode()).hexdigest()
+        t = os.path.getmtime(_history(cfg, "push2.md"))
+        eng.hasher.state["push2.md"] = {
+            "H": {"mtime": t, "size": len(old), "hash": h_old},
+        }
+        await eng.sync_file("push2.md")
+        assert os.path.exists(_icloud(cfg, "push2.md"))
+
+# ── Cooldown ──
+
+class TestCooldown:
+    @pytest.mark.asyncio
+    async def test_file_in_cooldown_is_skipped(self, eng, cfg):
+        _write(_local(cfg, "cool.md"), "x")
+        eng.cooldowns["cool.md"] = time.time() + 9999
+        initial_mtime = os.path.getmtime(_local(cfg, "cool.md"))
+        await eng.sync_file("cool.md")
+        assert not os.path.exists(_icloud(cfg, "cool.md"))
+
+    @pytest.mark.asyncio
+    async def test_expired_cooldown_allows_sync(self, eng, cfg):
+        _write(_local(cfg, "cool2.md"), "y" * 20)
+        eng.cooldowns["cool2.md"] = time.time() - 1
+        await eng.sync_file("cool2.md")
+        assert os.path.exists(_icloud(cfg, "cool2.md"))
+
+# ── iCloud guard ──
+
+class TestICloudGuard:
+    @pytest.mark.asyncio
+    async def test_cloud_only_state_defers_sync(self, eng, cfg):
+        _write(_local(cfg, "guarded.md"), "x")
+        _write(_icloud(cfg, "guarded.md"), "x")
+
+        mock_checker = MagicMock(spec=ICloudStatusChecker)
+        mock_checker.detect.return_value = ICloudSyncState.CLOUD_ONLY
+        mock_checker.is_safe.return_value = False
+        eng.icloud_checker = mock_checker
+        cfg.check_icloud_status = True
+
+        await eng.sync_file("guarded.md")
+        eng.log.info.assert_called()
+        assert open(_icloud(cfg, "guarded.md")).read() == "x"
+
+    @pytest.mark.asyncio
+    async def test_local_state_allows_sync(self, eng, cfg):
+        _write(_local(cfg, "ready.md"), "ready content")
+        _write(_icloud(cfg, "ready.md"), "old content")
+
+        mock_checker = MagicMock(spec=ICloudStatusChecker)
+        mock_checker.detect.return_value = ICloudSyncState.LOCAL
+        mock_checker.is_safe.return_value = True
+        eng.icloud_checker = mock_checker
+        cfg.check_icloud_status = True
+
+        _write(_history(cfg, "ready.md"), "old content")
+        h = hashlib.sha256(b"old content").hexdigest()
+        t = os.path.getmtime(_icloud(cfg, "ready.md"))
+        eng.hasher.state["ready.md"] = {
+            "C": {"mtime": t, "size": len("old content"), "hash": h},
+            "H": {"mtime": t, "size": len("old content"), "hash": h},
+        }
+        await eng.sync_file("ready.md")
+        assert open(_icloud(cfg, "ready.md")).read() == "ready content"
+
+# ── iCloud guard integration ──
+
+class TestICloudGuardIntegration:
+    @pytest.mark.asyncio
+    async def test_defers_when_unsafe(self, eng, cfg):
+        _write(_local(cfg, "guarded.md"), "x" * 50)
+        _write(_icloud(cfg, "guarded.md"), "original")
+        mock_checker = MagicMock()
+        mock_checker.detect.return_value = ICloudSyncState.CLOUD_ONLY
+        eng.icloud_checker = mock_checker
+        cfg.check_icloud_status = True
+        await eng.sync_file("guarded.md")
+        assert open(_icloud(cfg, "guarded.md")).read() == "original"
+
+    @pytest.mark.asyncio
+    async def test_allows_when_safe(self, eng, cfg):
+        _write(_local(cfg, "ready.md"), "updated content")
+        _write(_icloud(cfg, "ready.md"), "old content")
+        _write(_history(cfg, "ready.md"), "old content")
+        h = hashlib.sha256(b"old content").hexdigest()
+        t = os.path.getmtime(_icloud(cfg, "ready.md"))
+        eng.hasher.state["ready.md"] = {
+            "C": {"mtime": t, "size": len("old content"), "hash": h},
+            "H": {"mtime": t, "size": len("old content"), "hash": h},
+        }
+        mock_checker = MagicMock()
+        mock_checker.is_safe.return_value = True
+        eng.icloud_checker = mock_checker
+        cfg.check_icloud_status = True
+        await eng.sync_file("ready.md")
+        assert open(_icloud(cfg, "ready.md")).read() == "updated content"
+
+    @pytest.mark.asyncio
+    async def test_guard_skipped_when_checker_is_none(self, eng, cfg):
+        cfg.check_icloud_status = False
+        eng.icloud_checker = None
+        _write(_local(cfg, "bypass.md"), "x" * 50)
+        await eng.sync_file("bypass.md")
+        assert os.path.exists(_icloud(cfg, "bypass.md"))
+
+# ── Tiny file guard ──
+
+class TestTinyFiles:
+    @pytest.mark.asyncio
+    async def test_tiny_file_skipped_from_local(self, eng, cfg):
+        cfg.tiny_threshold = 10
+        _write(_local(cfg, "tiny.md"), "hi")
+        await eng.sync_file("tiny.md")
+        assert not os.path.exists(_icloud(cfg, "tiny.md"))
+
+    @pytest.mark.asyncio
+    async def test_obsidian_settings_not_skipped(self, eng, cfg):
+        cfg.tiny_threshold = 10
+        os.makedirs(os.path.join(cfg.local_vault, ".obsidian"), exist_ok=True)
+        _write(os.path.join(cfg.local_vault, ".obsidian", "app.json"), "{}")
+        await eng.sync_file(".obsidian/app.json")
+        assert os.path.exists(os.path.join(cfg.icloud_vault, ".obsidian", "app.json"))
+
+
+# ── push_to_icloud / restore_from_icloud ──
+
+class TestPushRestore:
+    @pytest.mark.asyncio
+    async def test_push_copies_to_icloud_and_history(self, eng, cfg):
+        _write(_local(cfg, "push.md"), "push content")
+        await eng.push_to_icloud("push.md")
+        assert os.path.exists(_icloud(cfg, "push.md"))
+        assert os.path.exists(_history(cfg, "push.md"))
+
+    @pytest.mark.asyncio
+    async def test_push_sets_cooldown(self, eng, cfg):
+        _write(_local(cfg, "cd.md"), "x")
+        await eng.push_to_icloud("cd.md")
+        assert "cd.md" in eng.cooldowns
+
+    @pytest.mark.asyncio
+    async def test_restore_copies_to_local_and_history(self, eng, cfg):
+        _write(_icloud(cfg, "restore.md"), "cloud content")
+        await eng.restore_from_icloud("restore.md")
+        assert os.path.exists(_local(cfg, "restore.md"))
+        assert os.path.exists(_history(cfg, "restore.md"))
+
+    @pytest.mark.asyncio
+    async def test_restore_sets_cooldown(self, eng, cfg):
+        _write(_icloud(cfg, "rcd.md"), "x")
+        await eng.restore_from_icloud("rcd.md")
+        assert "rcd.md" in eng.cooldowns
+
+# ── sync_wrapper ──
+
+class TestSyncWrapper:
+    @pytest.mark.asyncio
+    async def test_exception_is_caught_and_logged(self, eng, cfg):
+        eng.io.async_copy = AsyncMock(side_effect=RuntimeError("disk full"))
+        _write(_local(cfg, "broken.md"), "x" * 50)
+        await eng.sync_wrapper("broken.md")
+        eng.log.error.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_active_tasks_cleaned_on_exception(self, eng, cfg):
+        eng.io.async_copy = AsyncMock(side_effect=RuntimeError("boom"))
+        _write(_local(cfg, "task.md"), "x" * 50)
+        eng.active_tasks.add("task.md")
+        await eng.sync_wrapper("task.md")
+        assert "task.md" not in eng.active_tasks
+
+    @pytest.mark.asyncio
+    async def test_active_tasks_cleaned_on_success(self, eng, cfg):
+        _write(_local(cfg, "ok.md"), "x" * 50)
+        eng.active_tasks.add("ok.md")
+        await eng.sync_wrapper("ok.md")
+        assert "ok.md" not in eng.active_tasks
+
+# ── run() one-shot ──
+
+class TestRun:
+    @pytest.mark.asyncio
+    async def test_run_oneshot_processes_all_files(self, eng, cfg):
+        _write(_local(cfg, "a.md"), "a" * 50)
+        _write(_local(cfg, "b.md"), "a" * 50)
+        cfg.run_continuously = False
+        await eng.run()
+        assert os.path.exists(_icloud(cfg, "a.md"))
+        assert os.path.exists(_icloud(cfg, "b.md"))
+
+    @pytest.mark.asyncio
+    async def test_run_oneshot_saves_state(self, eng, cfg):
+        _write(_local(cfg, "x.md"), "yyy")
+        cfg.run_continuously = False
+        await eng.run()
+        assert os.path.exists(cfg.state_file_path)
+
+    @pytest.mark.asyncio
+    async def test_run_cleans_up_old_logs(self, eng, cfg):
+        cfg.run_continuously = False
+        with patch.object(eng.log, "cleanup_old_logs", new_callable=AsyncMock) as cl:
+            await eng.run()
+            cl.assert_called_once()
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
Added a Windows file attribute reader *icloud_status.py* that detects the current iCloud sync state of each file before any sync operation. Files that are cloud-only, pending download, or actively downloading are deferred until they become locally available. Also added a test suite for easier code review and regression coverage.

## Important

- In **DAEMON MODE**, right-clicking the iCloud vault directory -> *"Always keep on this device"* significantly improves sync reliability by keeping files locally pinned.
- It would be useful to add a `user_interface = True/False` config flag for users running the sync via Windows Task Scheduler (no interactive console).

Review the code @gursimar, if everything is correct, I think you can merge and add the UI.

## Run test
```
cd src\obsidian_sync\tests
python -m pytest -v
```

## References
https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntifs/nf-ntifs-rtlsetthreadplaceholdercompatibilitymode
https://learn.microsoft.com/en-us/windows/win32/wininet/api-flags