### PR TITLE
Fix: honor run_continuously=false to actually exit after one-shot sync

### DIFF
--- a/obsidian_sync/sync_engine.py
+++ b/obsidian_sync/sync_engine.py
@@ -237,7 +237,7 @@ class SyncEngine:
         await self.log.cleanup_old_logs()
         self.log.init_log_file()
         self.validate_config()
-        self.log.startup("DAEMON MODE")
+        self.log.startup("DAEMON MODE" if self.config.run_continuously else "ONE-SHOT MODE")
         self.hasher.load_state()
 
         self.loop = asyncio.get_running_loop()
@@ -248,6 +248,13 @@ class SyncEngine:
         try:
             observer.start()
             await self.seed_existing_files()
+
+            if not self.config.run_continuously:
+                # Wait for every file worker spawned during seeding to finish processing
+                # its queue, then fall through to the shared cleanup in `finally`.
+                if self.file_queues:
+                    await asyncio.gather(*(q.join() for q in self.file_queues.values()))
+                return
 
             while True:
                 try:


### PR DESCRIPTION
Fixes #13

`run_continuously: false` in `config.yaml` was parsed into `SyncConfig` but never actually checked in `SyncEngine.run()`:
- the startup log always printed "DAEMON MODE" regardless of the setting
- the main `while True:` loop never exited, so it kept running as a daemon forever even with `run_continuously: false`

**Change:**
- startup log now reflects the actual mode (`DAEMON MODE` / `ONE-SHOT MODE`)
- when `run_continuously` is `false`, after the initial seed, `run()` awaits `queue.join()` on every per-file queue spawned during seeding (so it genuinely waits for all initial sync work to finish, not just enqueue it) and then returns, falling through to the existing cleanup in `finally`

**Tested:** Windows 11, real vault (600+ files, two-way already in sync). Before the fix, a one-shot run with `run_continuously: false` never returned to the shell. After the fix it completes and exits cleanly in ~5s:

```
===========================================================================
  Obsidian Sync
  Mode:   ONE-SHOT MODE
  ...
===========================================================================
  DONE   Graceful shutdown complete.
```

No behavior change for the default (`run_continuously: true`) daemon mode.